### PR TITLE
fix: use https cloning for `mynewt-nimble` submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "mynewt-nimble"]
 	path = mynewt-nimble
-	url = git@github.com:apache/mynewt-nimble.git
+	url = https://github.com/apache/mynewt-nimble
 [submodule "nrfx"]
 	path = nrfx
 	url = https://github.com/NordicSemiconductor/nrfx


### PR DESCRIPTION
The ci.sh script fails in https://github.com/embassy-rs/trouble fails when including `apache-nimble` as a git dependency.
Setting the `mynewt-nimble` to be cloned with https over ssh fixed it.

```
Updating git submodule `git@github.com:apache/mynewt-nimble.git`
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
thread 'main' panicked at src/bin/cargo-batch.rs:134:85:
called `Result::unwrap()` on an `Err` value: failed to get `apache-nimble` as a dependency of package `trouble-apache-nimble-examples v0.1.0 (/home/gibbz/projects/personal/forks/trouble/examples/apache-nimble)`

Caused by:
    0: failed to load source for dependency `apache-nimble`
    1: Unable to update https://github.com/benbrittain/apache-nimble-sys
    2: failed to update submodule `mynewt-nimble`
    3: failed to fetch submodule `mynewt-nimble` from git@github.com:apache/mynewt-nimble.git
    4: process didn't exit successfully: `git fetch --tags --force --update-head-ok 'git@github.com:apache/mynewt-nimble.git' '+refs/heads/*:refs/remotes/origin/*' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```